### PR TITLE
Implement support for AWS SecretsManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "async-aws/ssm": "^1.3"
     },
     "require-dev": {
+        "async-aws/secrets-manager": "^1.0",
         "phpunit/phpunit": "^9.6.10",
         "mnapoli/hard-mode": "^0.3.0",
         "phpstan/phpstan": "^1.10.26"

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -2,6 +2,7 @@
 
 namespace Bref\Secrets;
 
+use AsyncAws\SecretsManager\SecretsManagerClient;
 use AsyncAws\Ssm\SsmClient;
 use Closure;
 use JsonException;
@@ -13,9 +14,10 @@ class Secrets
      * Decrypt environment variables that are encrypted with AWS SSM.
      *
      * @param SsmClient|null $ssmClient To allow mocking in tests.
+     * @param SecretsManagerClient|null $secretsManagerClient To allow mocking in tests.
      * @throws JsonException
      */
-    public static function loadSecretEnvironmentVariables(?SsmClient $ssmClient = null): void
+    public static function loadSecretEnvironmentVariables(?SsmClient $ssmClient = null, ?SecretsManagerClient $secretsManagerClient = null): void
     {
         /** @var array<string,string>|string|false $envVars */
         $envVars = getenv(local_only: true); // @phpstan-ignore-line PHPStan is wrong
@@ -23,36 +25,63 @@ class Secrets
             return;
         }
 
-        // Only consider environment variables that start with "bref-ssm:"
+        // Only consider environment variables that start with "bref-ssm:" or "bref-secretsmanager:"
         $envVarsToDecrypt = array_filter($envVars, function (string $value): bool {
-            return str_starts_with($value, 'bref-ssm:');
+            return str_starts_with($value, 'bref-ssm:') || str_starts_with($value, 'bref-secretsmanager:');
         });
         if (empty($envVarsToDecrypt)) {
             return;
         }
 
-        // Extract the SSM parameter names by removing the "bref-ssm:" prefix
-        $ssmNames = array_map(function (string $value): string {
-            return substr($value, strlen('bref-ssm:'));
-        }, $envVarsToDecrypt);
+        $ssmNames = [];
+        $secretsManagerNames = [];
+
+        // Extract the SSM and SecretsManager parameter names by removing the prefixes
+        foreach ($envVarsToDecrypt as $key => $envVar) {
+            if (str_starts_with($envVar, 'bref-ssm:')) {
+                $ssmNames[$key] = substr($envVar, strlen('bref-ssm:'));
+            }
+            if (str_starts_with($envVar, 'bref-secretsmanager:')) {
+                $secretsManagerNames[$key] = substr($envVar, strlen('bref-secretsmanager:'));
+            }
+        }
+
+        if (count($secretsManagerNames) > 0 && class_exists(SecretsManagerClient::class) === false) {
+            throw new RuntimeException('In order to load secrets from SecretsManager you must install "async-aws/secrets-manager" package');
+        }
 
         $actuallyCalledSsm = false;
-        $parameters = self::readParametersFromCacheOr(function () use ($ssmClient, $ssmNames, &$actuallyCalledSsm) {
-            $actuallyCalledSsm = true;
-            return self::retrieveParametersFromSsm($ssmClient, array_values($ssmNames));
-        });
+        if (count($ssmNames) > 0) {
+            $ssmParameters = self::readParametersFromCacheOr('ssm', function () use ($ssmClient, $ssmNames, &$actuallyCalledSsm) {
+                $actuallyCalledSsm = true;
+                return self::retrieveParametersFromSsm($ssmClient, array_values($ssmNames));
+            });
 
-        foreach ($parameters as $parameterName => $parameterValue) {
-            $envVar = array_search($parameterName, $ssmNames, true);
-            $_SERVER[$envVar] = $_ENV[$envVar] = $parameterValue;
-            putenv("$envVar=$parameterValue");
+            foreach ($ssmParameters as $parameterName => $parameterValue) {
+                $envVar = array_search($parameterName, $ssmNames, true);
+                $_SERVER[$envVar] = $_ENV[$envVar] = $parameterValue;
+                putenv("$envVar=$parameterValue");
+            }
+        }
+
+        $actuallyCalledSecretsManager = false;
+        if (count($secretsManagerNames) > 0) {
+            $secretsManagerParameters = self::readParametersFromCacheOr('secretsmanager', function () use ($secretsManagerClient, $secretsManagerNames, &$actuallyCalledSecretsManager) {
+                $actuallyCalledSecretsManager = true;
+                return self::retrieveParametersFromSecretsManager($secretsManagerClient, $secretsManagerNames);
+            });
+
+            foreach ($secretsManagerParameters as $parameterName => $parameterValue) {
+                $_SERVER[$parameterName] = $_ENV[$parameterName] = $parameterValue;
+                putenv("$parameterName=$parameterValue");
+            }
         }
 
         // Only log once (when the cache was empty) else it might spam the logs in the function runtime
         // (where the process restarts on every invocation)
-        if ($actuallyCalledSsm) {
+        if ($actuallyCalledSsm || $actuallyCalledSecretsManager) {
             $stderr = fopen('php://stderr', 'ab');
-            fwrite($stderr, '[Bref] Loaded these environment variables from SSM: ' . implode(', ', array_keys($envVarsToDecrypt)) . PHP_EOL);
+            fwrite($stderr, '[Bref] Loaded these environment variables from SSM/SecretsManager: ' . implode(', ', array_keys($envVarsToDecrypt)) . PHP_EOL);
         }
     }
 
@@ -60,16 +89,17 @@ class Secrets
      * Cache the parameters in a temp file.
      * Why? Because on the function runtime, the PHP process might
      * restart on every invocation (or on error), so we don't want to
-     * call SSM every time.
+     * call SSM/SecretsManager every time.
      *
+     * @param string $paramType
      * @param Closure(): array<string, string> $paramResolver
      * @return array<string, string> Map of parameter name -> value
      * @throws JsonException
      */
-    private static function readParametersFromCacheOr(Closure $paramResolver): array
+    private static function readParametersFromCacheOr(string $paramType, Closure $paramResolver): array
     {
         // Check in cache first
-        $cacheFile = sys_get_temp_dir() . '/bref-ssm-parameters.php';
+        $cacheFile = sprintf('%s/bref-%s-parameters.php', sys_get_temp_dir(), $paramType);
         if (is_file($cacheFile)) {
             $parameters = json_decode(file_get_contents($cacheFile), true, 512, JSON_THROW_ON_ERROR);
             if (is_array($parameters)) {
@@ -82,6 +112,49 @@ class Secrets
 
         // Using json_encode instead of var_export due to possible security issues
         file_put_contents($cacheFile, json_encode($parameters, JSON_THROW_ON_ERROR));
+
+        return $parameters;
+    }
+
+    /**
+     * @param string[] $secretNames
+     * @return array<string, string> Map of parameter name -> value
+     * @throws JsonException
+     */
+    private static function retrieveParametersFromSecretsManager(
+        ?SecretsManagerClient $secretsManagerClient,
+        array $secretNames
+    ): array {
+        $secretsManager = $secretsManagerClient ?? new SecretsManagerClient([
+            'region' => $_ENV['AWS_REGION'] ?? $_ENV['AWS_DEFAULT_REGION'],
+        ]);
+
+        /** @var array<string, string> $parameters Map of parameter name -> value */
+        $parameters = [];
+
+        foreach ($secretNames as $secretId) {
+            try {
+                $result = $secretsManager->getSecretValue([
+                    'SecretId' => $secretId,
+                ]);
+                $secretString = $result->getSecretString();
+            } catch (RuntimeException $e) {
+                if ($e->getCode() === 400) {
+                    // Extra descriptive error message for the most common error
+                    throw new RuntimeException(
+                        "Bref was not able to resolve secrets contained in environment variables from SecretsManager because of a permissions issue with the SecretsManager API. Did you add IAM permissions in serverless.yml to allow Lambda to access SecretsManager? (docs: https://bref.sh/docs/environment/variables.html#at-deployment-time).\nFull exception message: {$e->getMessage()}",
+                        $e->getCode(),
+                        $e,
+                    );
+                }
+                throw $e;
+            }
+
+            $secretValues = json_decode($secretString, true, 512, JSON_THROW_ON_ERROR);
+            foreach ($secretValues as $name => $value) {
+                $parameters[$name] = $value;
+            }
+        }
 
         return $parameters;
     }

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -3,6 +3,8 @@
 namespace Bref\Secrets\Test;
 
 use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\SecretsManager\Result\GetSecretValueResponse;
+use AsyncAws\SecretsManager\SecretsManagerClient;
 use AsyncAws\Ssm\Result\GetParametersResult;
 use AsyncAws\Ssm\SsmClient;
 use AsyncAws\Ssm\ValueObject\Parameter;
@@ -15,6 +17,9 @@ class SecretsTest extends TestCase
     {
         if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters.php')) {
             unlink(sys_get_temp_dir() . '/bref-ssm-parameters.php');
+        }
+        if (file_exists(sys_get_temp_dir() . '/bref-secretsmanager-parameters.php')) {
+            unlink(sys_get_temp_dir() . '/bref-secretsmanager-parameters.php');
         }
     }
 
@@ -32,6 +37,79 @@ class SecretsTest extends TestCase
         $this->assertSame('foobar', getenv('SOME_VARIABLE'));
         $this->assertSame('foobar', $_SERVER['SOME_VARIABLE']);
         $this->assertSame('foobar', $_ENV['SOME_VARIABLE']);
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+    }
+
+    public function test decrypts env variables from secretsmanager(): void
+    {
+        putenv('SOME_VARIABLE=bref-secretsmanager:/some/parameter');
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertSame('bref-secretsmanager:/some/parameter', getenv('SOME_VARIABLE'));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        Secrets::loadSecretEnvironmentVariables(null, $this->mockSecretsManagerClient());
+
+        $this->assertSame('foobar_1', getenv('SOME_VARIABLE_1'));
+        $this->assertSame('foobar_1', $_SERVER['SOME_VARIABLE_1']);
+        $this->assertSame('foobar_1', $_ENV['SOME_VARIABLE_1']);
+        $this->assertSame('foobar_2', getenv('SOME_VARIABLE_2'));
+        $this->assertSame('foobar_2', $_SERVER['SOME_VARIABLE_2']);
+        $this->assertSame('foobar_2', $_ENV['SOME_VARIABLE_2']);
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+    }
+
+    public function test decrypts env variables from both ssm and secretsmanager(): void
+    {
+        putenv('SOME_VARIABLE=bref-ssm:/some/parameter');
+        putenv('SOME_VARIABLE_1=bref-secretsmanager:/some/parameter');
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertSame('bref-ssm:/some/parameter', getenv('SOME_VARIABLE'));
+        $this->assertSame('bref-secretsmanager:/some/parameter', getenv('SOME_VARIABLE_1'));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        Secrets::loadSecretEnvironmentVariables($this->mockSsmClient(), $this->mockSecretsManagerClient());
+
+        // Check value from ssm
+        $this->assertSame('foobar', getenv('SOME_VARIABLE'));
+        $this->assertSame('foobar', $_SERVER['SOME_VARIABLE']);
+        $this->assertSame('foobar', $_ENV['SOME_VARIABLE']);
+        // Check value from secretsmanager
+        $this->assertSame('foobar_1', getenv('SOME_VARIABLE_1'));
+        $this->assertSame('foobar_1', $_SERVER['SOME_VARIABLE_1']);
+        $this->assertSame('foobar_1', $_ENV['SOME_VARIABLE_1']);
+        $this->assertSame('foobar_2', getenv('SOME_VARIABLE_2'));
+        $this->assertSame('foobar_2', $_SERVER['SOME_VARIABLE_2']);
+        $this->assertSame('foobar_2', $_ENV['SOME_VARIABLE_2']);
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+    }
+
+    public function test env variables from secretsmanager overrides ssm(): void
+    {
+        putenv('SOME_VARIABLE=bref-ssm:/some/parameter');
+        putenv('SOME_VARIABLE_1=bref-secretsmanager:/some/parameter');
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertSame('bref-ssm:/some/parameter', getenv('SOME_VARIABLE'));
+        $this->assertSame('bref-secretsmanager:/some/parameter', getenv('SOME_VARIABLE_1'));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        Secrets::loadSecretEnvironmentVariables(
+            $this->mockSsmClient(),
+            $this->mockSecretsManagerClient('{"SOME_VARIABLE":"foobar_from_secretsmanager"}')
+        );
+
+        // Check value from ssm
+        $this->assertSame('foobar_from_secretsmanager', getenv('SOME_VARIABLE'));
+        $this->assertSame('foobar_from_secretsmanager', $_SERVER['SOME_VARIABLE']);
+        $this->assertSame('foobar_from_secretsmanager', $_ENV['SOME_VARIABLE']);
         // Check that the other variable was not modified
         $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
     }
@@ -62,6 +140,27 @@ class SecretsTest extends TestCase
         $expected = preg_quote("Bref was not able to resolve secrets contained in environment variables from SSM because of a permissions issue with the SSM API. Did you add IAM permissions in serverless.yml to allow Lambda to access SSM? (docs: https://bref.sh/docs/environment/variables.html#at-deployment-time).\nFull exception message:", '/');
         $this->expectExceptionMessageMatches("/$expected .+/");
         Secrets::loadSecretEnvironmentVariables($ssmClient);
+    }
+
+    private function mockSecretsManagerClient(?string $secretString = null): SecretsManagerClient
+    {
+        $secretsManagerClient = $this->getMockBuilder(SecretsManagerClient::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSecretValue'])
+            ->getMock();
+
+        $result = ResultMockFactory::create(GetSecretValueResponse::class, [
+            'SecretString' => $secretString ?? '{"SOME_VARIABLE_1":"foobar_1","SOME_VARIABLE_2":"foobar_2"}',
+        ]);
+
+        $secretsManagerClient->expects($this->once())
+            ->method('getSecretValue')
+            ->with([
+                'SecretId' => '/some/parameter',
+            ])
+            ->willReturn($result);
+
+        return $secretsManagerClient;
     }
 
     private function mockSsmClient(): SsmClient


### PR DESCRIPTION
Hi there 👋 

`secrets-loader` is great, easy to setup, and works beautifuly with AWS SSM.

However, most of our projects work with both SSM and SecretsManager, 
This PR allows people to use natively use secrets from SecretsManager with Bref.
