### PR TITLE
feat: implement support for AWS Secrets Manager (alternative)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,11 @@
         "async-aws/ssm": "^1.3"
     },
     "require-dev": {
+        "async-aws/secrets-manager": "^1.0",
         "phpunit/phpunit": "^9.6.10",
         "mnapoli/hard-mode": "^0.3.0",
-        "phpstan/phpstan": "^1.10.26"
+        "phpstan/phpstan": "^1.10.26",
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "config": {
         "allow-plugins": {

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -37,7 +37,7 @@ class Secrets
         $ssmNames = [];
         $secretsManagerNames = [];
 
-        // Extract the SSM and SecretsManager parameter names by removing the prefixes
+        // Extract the SSM and Secrets Manager parameter names by removing the prefixes
         foreach ($envVarsToDecrypt as $key => $envVar) {
             if (str_starts_with($envVar, 'bref-ssm:')) {
                 $ssmNames[$key] = substr($envVar, strlen('bref-ssm:'));
@@ -91,7 +91,7 @@ class Secrets
      * Cache the parameters in a temp file.
      * Why? Because on the function runtime, the PHP process might
      * restart on every invocation (or on error), so we don't want to
-     * call SSM/SecretsManager every time.
+     * call SSM/Secrets Manager every time.
      *
      * @param Closure(): array<string, string> $paramResolver
      * @return array<string, string> Map of parameter name -> value
@@ -158,7 +158,7 @@ class Secrets
             });
 
             throw new RuntimeException(
-                'The following SecretsManager parameters could not be found: ' . implode(', ', $parametersNotFound) .'. Did you add IAM permissions in serverless.yml to allow Lambda to access SecretsManager?',
+                'The following secrets from Secrets Manager could not be found: ' . implode(', ', $parametersNotFound) .'. Did you add IAM permissions in serverless.yml to allow Lambda to access Secrets Manager?',
             );
         }
 


### PR DESCRIPTION
I tried the existing PR https://github.com/brefphp/secrets-loader/pull/4 but I think it's way too opinionated about the format of secrets since it expects every secret to be a JSON. Also, it magically sets environment variables from the actual content of the secret. This is an alternative approach which simply writes the value of a secret to the environment variable. Parsing values from JSON might be a different story for a new PR. What do you think?