### PR TITLE
Have a SSM parameter containing many application environment variables in ini format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ provider:
 
 In AWS Lambda, the `MY_PARAMETER` would be automatically replaced and would contain the value stored at `/my-app/my-parameter` in AWS SSM Parameters.
 
+It could be also used to read a set of parameters from a SSM variable that contains a string in an INI format. 
+For example, if there is an SSM parameter `/my-app/my-par-store` that contains this sting:
+```ini
+FOO=bar
+BAR=baz
+```
+and we have this `severless.yml` configuration with the special variable `BREF_PARAMETER_STORE` set this way:
+```yaml
+provider:
+    # ...
+    environment:
+      BREF_PARAMETER_STORE: ssm:/my-app/my-par-store
+```
+our lambda will see the these environment variables:
+```shell
+FOO=bar
+BAR=baz
+```
+
 This feature is shipped as a separate package so that all its code and dependencies are not installed by default for all Bref users. Install this package if you want to use the feature.
 
 ## Installation

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -26,7 +26,7 @@ class Secrets
         }
 
         if (\key_exists(self::PARAMETER_STORE_VAR_NAME, $envVars)) {
-            self::readEnvFromParameterStore($envVars[self::PARAMETER_STORE_VAR_NAME], $ssmClient);
+            self::readEnvFromCacheOrParameterStore($envVars[self::PARAMETER_STORE_VAR_NAME], $ssmClient);
         }
 
         // Only consider environment variables that start with "bref-ssm:"
@@ -141,15 +141,37 @@ class Secrets
      * @param bool|int|string $envVar
      * @return void
      */
-    public static function setIniValue(string $parameterValue, bool|int|string $envVar): void
+    private static function setIniValue(string $parameterValue, bool|int|string $envVar): void
     {
         $_SERVER[$envVar] = $_ENV[$envVar] = $parameterValue;
         putenv("$envVar=$parameterValue");
     }
 
-    private static function readEnvFromParameterStore(string $parameterStoreName, ?SsmClient $ssmClient): void
+    private static function readEnvFromCacheOrParameterStore(string $parameterStoreName, ?SsmClient $ssmClient): bool
     {
-        // The ssm: prefix will allow to implement a secretsmanager prefix in the future
+        $cacheFile = sys_get_temp_dir() . '/bref-ssm-parameters-store.ini';
+        if (is_file($cacheFile)) {
+            $values = parse_ini_file($cacheFile);
+            if (false === $values) {
+                throw new \RuntimeException('Error parsing data from parameter store');
+            }
+            $actuallyCalledSsm = false;
+        } else {
+            $values = self::readEnvFromParameterStore($parameterStoreName, $ssmClient);
+            self::write_to_ini($cacheFile, $values);
+            $actuallyCalledSsm = true;
+        }
+
+        foreach ($values as $key => $value) {
+            self::setIniValue($value, $key);
+        }
+
+        return $actuallyCalledSsm;
+    }
+
+    private static function readEnvFromParameterStore(string $parameterStoreName, ?SsmClient $ssmClient): array
+    {
+        // The ssm: prefix will allow to implement a secretsmanager: prefix in the future
         $cleanParameterStoreName = substr($parameterStoreName, strlen('ssm:'));
 
         $iniValues = self::retrieveParametersFromSsm($ssmClient, [$cleanParameterStoreName])[$cleanParameterStoreName];
@@ -159,8 +181,15 @@ class Secrets
             throw new \RuntimeException('Error parsing data from parameter store');
         }
 
+        return $values;
+    }
+
+    private static function write_to_ini(string $fileName, array $values): void {
+        $content = '';
         foreach ($values as $key => $value) {
-            self::setIniValue($value, $key);
+            $content .= "$key = $value" . PHP_EOL;
         }
+
+        file_put_contents($fileName, $content, FILE_APPEND) !== false;
     }
 }

--- a/src/Secrets.php
+++ b/src/Secrets.php
@@ -163,7 +163,7 @@ class Secrets
      *  VAR1=foo
      *  VAR2=bar
      *
-     * @param string$parameterStoreName The name of the SSM variable containing the ini formatted string
+     * @param string$parameterStoreName The name of the SSM parameter containing the ini formatted string
      * @param SsmClient|null $ssmClient To allow mocking in tests.
      * @throws JsonException
      */

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -16,6 +16,11 @@ class SecretsTest extends TestCase
         if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters.php')) {
             unlink(sys_get_temp_dir() . '/bref-ssm-parameters.php');
         }
+        putenv('SOME_VARIABLE');
+        putenv('SOME_OTHER_VARIABLE');
+        putenv(Secrets::PARAMETER_STORE_VAR_NAME);
+        putenv('FOO');
+        putenv('BAR');
     }
 
     public function test decrypts env variables(): void
@@ -29,9 +34,30 @@ class SecretsTest extends TestCase
 
         Secrets::loadSecretEnvironmentVariables($this->mockSsmClient());
 
-        $this->assertSame('foobar', getenv('SOME_VARIABLE'));
-        $this->assertSame('foobar', $_SERVER['SOME_VARIABLE']);
-        $this->assertSame('foobar', $_ENV['SOME_VARIABLE']);
+        $this->asserVarIsSet('foobar', 'SOME_VARIABLE');
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+    }
+
+    public function test decrypts env variables from parameter store(): void
+    {
+        putenv(Secrets::PARAMETER_STORE_VAR_NAME.'=ssm:/some/parameter');
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertSame('ssm:/some/parameter', getenv('BREF_PARAMETER_STORE'));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        $storeContents=<<<'END'
+        FOO=bar
+        BAR=baz
+        END;
+
+        Secrets::loadSecretEnvironmentVariables($this->mockSsmClient($storeContents));
+
+        $this->asserVarIsSet('bar', 'FOO');
+        $this->asserVarIsSet('baz', 'BAR');
+
         // Check that the other variable was not modified
         $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
     }
@@ -46,6 +72,19 @@ class SecretsTest extends TestCase
         Secrets::loadSecretEnvironmentVariables($ssmClient);
 
         $this->assertSame('foobar', getenv('SOME_VARIABLE'));
+    }
+
+    public function test caches parameters from parameter store to call SSM only once(): void
+    {
+        putenv(Secrets::PARAMETER_STORE_VAR_NAME.'=ssm:/some/parameter');
+
+        // Call twice, the mock will assert that SSM was only called once
+        $ssmClient = $this->mockSsmClient();
+        Secrets::loadSecretEnvironmentVariables($ssmClient);
+        Secrets::loadSecretEnvironmentVariables($ssmClient);
+
+        $this->asserVarIsSet('bar', 'FOO');
+        $this->asserVarIsSet('baz', 'BAR');
     }
 
     public function test throws a clear error message on missing permissions(): void
@@ -64,7 +103,7 @@ class SecretsTest extends TestCase
         Secrets::loadSecretEnvironmentVariables($ssmClient);
     }
 
-    private function mockSsmClient(): SsmClient
+    private function mockSsmClient(string $parameterValue = 'foobar'): SsmClient
     {
         $ssmClient = $this->getMockBuilder(SsmClient::class)
             ->disableOriginalConstructor()
@@ -75,7 +114,7 @@ class SecretsTest extends TestCase
             'Parameters' => [
                 new Parameter([
                     'Name' => '/some/parameter',
-                    'Value' => 'foobar',
+                    'Value' => $parameterValue,
                 ]),
             ],
         ]);
@@ -89,5 +128,12 @@ class SecretsTest extends TestCase
             ->willReturn($result);
 
         return $ssmClient;
+    }
+
+    private function asserVarIsSet(string $value, string $varName): void
+    {
+        $this->assertSame($value, getenv($varName));
+        $this->assertSame($value, $_SERVER[$varName]);
+        $this->assertSame($value, $_ENV[$varName]);
     }
 }

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -16,8 +16,8 @@ class SecretsTest extends TestCase
         if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters.php')) {
             unlink(sys_get_temp_dir() . '/bref-ssm-parameters.php');
         }
-        if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters-store.ini')) {
-            unlink(sys_get_temp_dir() . '/bref-ssm-parameters-store.ini');
+        if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters-store.json')) {
+            unlink(sys_get_temp_dir() . '/bref-ssm-parameters-store.json');
         }
         putenv('SOME_VARIABLE');
         putenv('SOME_OTHER_VARIABLE');

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -56,14 +56,14 @@ class SecretsTest extends TestCase
 
     public function test decrypts env variables from parameter store(): void
     {
-        putenv(Secrets::PARAMETER_STORE_VAR_NAME.'=ssm:/some/parameter');
+        putenv(Secrets::PARAMETER_STORE_VAR_NAME . '=ssm:/some/parameter');
         putenv('SOME_OTHER_VARIABLE=helloworld');
 
         // Sanity checks
         $this->assertSame('ssm:/some/parameter', getenv('BREF_PARAMETER_STORE'));
         $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
 
-        $storeContents=<<<'END'
+        $storeContents = <<<'END'
         FOO=bar
         BAR=baz
         END;
@@ -79,14 +79,14 @@ class SecretsTest extends TestCase
 
     public function test caches parameters from parameter store to call SSM only once(): void
     {
-        putenv(Secrets::PARAMETER_STORE_VAR_NAME.'=ssm:/some/parameter');
+        putenv(Secrets::PARAMETER_STORE_VAR_NAME . '=ssm:/some/parameter');
         putenv('SOME_OTHER_VARIABLE=helloworld');
 
         // Sanity checks
         $this->assertSame('ssm:/some/parameter', getenv('BREF_PARAMETER_STORE'));
         $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
 
-        $storeContents=<<<'END'
+        $storeContents = <<<'END'
         FOO=bar
         BAR=baz
         END;


### PR DESCRIPTION
Migrating an existing complex Symfony application to Bref leads to having many environment variables defined in `serverless.yml`.
Instead of having a one to one mapping between lambda environment variables and SSM parameters, I suggest to have a single lambda environment variable with the special name `BREF_PARAMETER_STORE` that stores a string in ini format. That string will be expanded in many application environment variables.
For example a lambda could have the environment variable `BREF_PARAMETER_STORE=ssm:/some/parameter`. Data contained in that parameter could be:
```
VAR1=foo
VAR2=bar
```
The lambda exection runtime should then see `VAR1=foo` and `VAR2=bar` as environment variables. I suggest to use the `ssn:` prefix in front of the value of the parameter to let a future implementation using Secrets Manager.

This change is fully compatible with the existing behavior.