### PR TITLE
feat: add dotenv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /composer.phar
 /composer.lock
 /.phpunit.result.cache
+.env
+.env*
+/tests/env/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require": {
         "php": ">=8.0",
-        "async-aws/ssm": "^1.3"
+        "async-aws/ssm": "^1.3",
+        "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.10",

--- a/tests/SecretsTest.php
+++ b/tests/SecretsTest.php
@@ -11,10 +11,60 @@ use PHPUnit\Framework\TestCase;
 
 class SecretsTest extends TestCase
 {
+
+    const envToReset = [
+        'SOME_VARIABLE',
+        'SOME_OTHER_VARIABLE',
+        'APP_ENV',
+        'BREF_ENV',
+        'BREF_ENV_PATH',
+        'LAMBDA_TASK_ROOT'
+    ];
+
+    const envFilesToCleanup = [
+        '.env',
+        '.env.foobar'
+    ];
+
+    public static function tearDownAfterClass(): void
+    {
+        self::cleanupFiles();
+        parent::tearDownAfterClass();
+
+    }
+
     public function setUp(): void
+    {
+
+        self::cleanupFiles();
+
+        // reset env
+        array_map(function ($env) {
+            putenv($env);
+            unset($_ENV[$env], $_SERVER[$env]);
+        }, self::envToReset);
+    }
+
+    protected static function cleanupFiles()
     {
         if (file_exists(sys_get_temp_dir() . '/bref-ssm-parameters.php')) {
             unlink(sys_get_temp_dir() . '/bref-ssm-parameters.php');
+        }
+
+        // cleanup dotenv files
+        array_map(function ($envFile){
+
+            if (file_exists(getcwd() .'/'. $envFile)) {
+                unlink(getcwd()  .'/'.  $envFile);
+            }
+
+            if (file_exists(__DIR__ . '/env/' . $envFile)) {
+                unlink(__DIR__ . '/env/' . $envFile);
+            }
+        }, self::envFilesToCleanup);
+
+        if(file_exists(__DIR__ . '/env')) {
+            rmdir(__DIR__ . '/env');
         }
     }
 
@@ -62,6 +112,61 @@ class SecretsTest extends TestCase
         $expected = preg_quote("Bref was not able to resolve secrets contained in environment variables from SSM because of a permissions issue with the SSM API. Did you add IAM permissions in serverless.yml to allow Lambda to access SSM? (docs: https://bref.sh/docs/environment/variables.html#at-deployment-time).\nFull exception message:", '/');
         $this->expectExceptionMessageMatches("/$expected .+/");
         Secrets::loadSecretEnvironmentVariables($ssmClient);
+    }
+
+
+    public function testLoadsSecretsFromDotenv(): void
+    {
+        copy(__DIR__ . '/fixtures/.env', getcwd() . '/.env');
+        putenv('SOME_VARIABLE');
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertFalse(getenv('SOME_VARIABLE'));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        Secrets::loadSecretEnvironmentVariables($this->mockSsmClient());
+
+        $this->assertSame('foobar', getenv('SOME_VARIABLE'));
+        $this->assertSame('foobar', $_SERVER['SOME_VARIABLE']);
+        $this->assertSame('foobar', $_ENV['SOME_VARIABLE']);
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+    }
+
+    /**
+     * @testWith [null, "BREF_ENV"]
+     *           [null, "APP_ENV"]
+     *           ["BREF_ENV_PATH", "BREF_ENV"]
+     *           ["BREF_ENV_PATH", "APP_ENV"]
+     *           ["LAMBDA_TASK_ROOT", "BREF_ENV"]
+     *           ["LAMBDA_TASK_ROOT", "APP_ENV"]
+     */
+    public function testLoadsSecretsFromDotenvForSpecificEnv(?string $envPath, string $envKey): void
+    {
+        if ($envPath) {
+            putenv("$envPath=" . __DIR__ . '/env');
+        }
+
+        $envPath = $envPath ? __DIR__ . '/env' : getcwd();
+        mkdir( __DIR__ . '/env');
+        copy(__DIR__ . '/fixtures/.env', "$envPath/.env.foobar");
+        putenv('SOME_VARIABLE');
+        putenv("$envKey=foobar");
+        putenv('SOME_OTHER_VARIABLE=helloworld');
+
+        // Sanity checks
+        $this->assertFalse(getenv('SOME_VARIABLE'));
+        $this->assertSame('foobar', getenv($envKey));
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
+
+        Secrets::loadSecretEnvironmentVariables($this->mockSsmClient());
+
+        $this->assertSame('foobar', getenv('SOME_VARIABLE'));
+        $this->assertSame('foobar', $_SERVER['SOME_VARIABLE']);
+        $this->assertSame('foobar', $_ENV['SOME_VARIABLE']);
+        // Check that the other variable was not modified
+        $this->assertSame('helloworld', getenv('SOME_OTHER_VARIABLE'));
     }
 
     private function mockSsmClient(): SsmClient

--- a/tests/fixtures/.env
+++ b/tests/fixtures/.env
@@ -1,0 +1,2 @@
+SOME_VARIABLE=bref-ssm:/some/parameter
+SOME_OTHER_VARIABLE=i-should-not-overwrite-existing-value


### PR DESCRIPTION
Lambda environment variables have [a default 4 KB service quota that can't be increased.](https://repost.aws/knowledge-center/lambda-environment-variable-size)

If using a large enough number of runtime-loaded secrets it is easy to hit this limit. We did so at around 77 env vars, your mileage may vary depending on the length of env names and ssm paths.

To support an arbitrary number of variables this PR adds dotenv support to the secrets loader.

The loader will gather env from the system environment as usual and then load and merge variables from a dotenv file before retrieving and replacing any secret values necessary from ssm.

Dotenv is used in its immutable mode meaning values in the dotenv file will not replace/overwrite existing variables.

Since this is also the default/suggested behavior when dotenv used in popular frameworks like laravel and symfony there is no risk of conflict if a framwork later reloads the same dotenv file, the retrieved secret values will not be replaced with the ssm paths again.

By default it will look for dotenv files in the `LAMBDA_TASK_ROOT` path, however you can define `BREF_ENV_PATH` to change this.
The file loaded will be determined by looking for an environment name in `BREF_ENV`, falling back to the popular `APP_ENV`. if a value is found the file loaded will be `.env.{environment name}` else it will attempt to load `.env`.
missing files will be safely ignored.

These `BREF_ENV_PATH`, `BREF_ENV` and `APP_ENV` values would need to remain defined on the lambda itself if required and not in a dotenv file, but all other environment values could be moved to a dotenv.

N.B. due to the issue in my related PR on the bref repo unless/until that chaneg is merged you would also need at least one enviroment variable defined on the lambda itself that has a `bref-ssm:...` value in order to trigger the secrets loading.

